### PR TITLE
Add Get/Set functions & other general improvements

### DIFF
--- a/inflections.go
+++ b/inflections.go
@@ -33,81 +33,87 @@ type inflection struct {
 	replace string
 }
 
+// Regular is a regexp find replace inflection
 type Regular struct {
 	find    string
 	replace string
 }
 
+// Irregular is a hard replace inflection,
+// containing both singular and plural forms
 type Irregular struct {
 	singular string
 	plural   string
 }
 
+// RegularSlice is a slice of Regular inflections
 type RegularSlice []Regular
+
+// IrregularSlice is a slice of Irregular inflections
 type IrregularSlice []Irregular
 
 var pluralInflections = RegularSlice{
-	{find: "([a-z])$", replace: "${1}s"},
-	{find: "s$", replace: "s"},
-	{find: "^(ax|test)is$", replace: "${1}es"},
-	{find: "(octop|vir)us$", replace: "${1}i"},
-	{find: "(octop|vir)i$", replace: "${1}i"},
-	{find: "(alias|status)$", replace: "${1}es"},
-	{find: "(bu)s$", replace: "${1}ses"},
-	{find: "(buffal|tomat)o$", replace: "${1}oes"},
-	{find: "([ti])um$", replace: "${1}a"},
-	{find: "([ti])a$", replace: "${1}a"},
-	{find: "sis$", replace: "ses"},
-	{find: "(?:([^f])fe|([lr])f)$", replace: "${1}${2}ves"},
-	{find: "(hive)$", replace: "${1}s"},
-	{find: "([^aeiouy]|qu)y$", replace: "${1}ies"},
-	{find: "(x|ch|ss|sh)$", replace: "${1}es"},
-	{find: "(matr|vert|ind)(?:ix|ex)$", replace: "${1}ices"},
-	{find: "^(m|l)ouse$", replace: "${1}ice"},
-	{find: "^(m|l)ice$", replace: "${1}ice"},
-	{find: "^(ox)$", replace: "${1}en"},
-	{find: "^(oxen)$", replace: "${1}"},
-	{find: "(quiz)$", replace: "${1}zes"},
+	{"([a-z])$", "${1}s"},
+	{"s$", "s"},
+	{"^(ax|test)is$", "${1}es"},
+	{"(octop|vir)us$", "${1}i"},
+	{"(octop|vir)i$", "${1}i"},
+	{"(alias|status)$", "${1}es"},
+	{"(bu)s$", "${1}ses"},
+	{"(buffal|tomat)o$", "${1}oes"},
+	{"([ti])um$", "${1}a"},
+	{"([ti])a$", "${1}a"},
+	{"sis$", "ses"},
+	{"(?:([^f])fe|([lr])f)$", "${1}${2}ves"},
+	{"(hive)$", "${1}s"},
+	{"([^aeiouy]|qu)y$", "${1}ies"},
+	{"(x|ch|ss|sh)$", "${1}es"},
+	{"(matr|vert|ind)(?:ix|ex)$", "${1}ices"},
+	{"^(m|l)ouse$", "${1}ice"},
+	{"^(m|l)ice$", "${1}ice"},
+	{"^(ox)$", "${1}en"},
+	{"^(oxen)$", "${1}"},
+	{"(quiz)$", "${1}zes"},
 }
 
 var singularInflections = RegularSlice{
-	{find: "s$", replace: ""},
-	{find: "(ss)$", replace: "${1}"},
-	{find: "(n)ews$", replace: "${1}ews"},
-	{find: "([ti])a$", replace: "${1}um"},
-	{find: "((a)naly|(b)a|(d)iagno|(p)arenthe|(p)rogno|(s)ynop|(t)he)(sis|ses)$", replace: "${1}sis"},
-	{find: "(^analy)(sis|ses)$", replace: "${1}sis"},
-	{find: "([^f])ves$", replace: "${1}fe"},
-	{find: "(hive)s$", replace: "${1}"},
-	{find: "(tive)s$", replace: "${1}"},
-	{find: "([lr])ves$", replace: "${1}f"},
-	{find: "([^aeiouy]|qu)ies$", replace: "${1}y"},
-	{find: "(s)eries$", replace: "${1}eries"},
-	{find: "(m)ovies$", replace: "${1}ovie"},
-	{find: "(c)ookies$", replace: "${1}ookie"},
-	{find: "(x|ch|ss|sh)es$", replace: "${1}"},
-	{find: "^(m|l)ice$", replace: "${1}ouse"},
-	{find: "(bus)(es)?$", replace: "${1}"},
-	{find: "(o)es$", replace: "${1}"},
-	{find: "(shoe)s$", replace: "${1}"},
-	{find: "(cris|test)(is|es)$", replace: "${1}is"},
-	{find: "^(a)x[ie]s$", replace: "${1}xis"},
-	{find: "(octop|vir)(us|i)$", replace: "${1}us"},
-	{find: "(alias|status)(es)?$", replace: "${1}"},
-	{find: "^(ox)en", replace: "${1}"},
-	{find: "(vert|ind)ices$", replace: "${1}ex"},
-	{find: "(matr)ices$", replace: "${1}ix"},
-	{find: "(quiz)zes$", replace: "${1}"},
-	{find: "(database)s$", replace: "${1}"},
+	{"s$", ""},
+	{"(ss)$", "${1}"},
+	{"(n)ews$", "${1}ews"},
+	{"([ti])a$", "${1}um"},
+	{"((a)naly|(b)a|(d)iagno|(p)arenthe|(p)rogno|(s)ynop|(t)he)(sis|ses)$", "${1}sis"},
+	{"(^analy)(sis|ses)$", "${1}sis"},
+	{"([^f])ves$", "${1}fe"},
+	{"(hive)s$", "${1}"},
+	{"(tive)s$", "${1}"},
+	{"([lr])ves$", "${1}f"},
+	{"([^aeiouy]|qu)ies$", "${1}y"},
+	{"(s)eries$", "${1}eries"},
+	{"(m)ovies$", "${1}ovie"},
+	{"(c)ookies$", "${1}ookie"},
+	{"(x|ch|ss|sh)es$", "${1}"},
+	{"^(m|l)ice$", "${1}ouse"},
+	{"(bus)(es)?$", "${1}"},
+	{"(o)es$", "${1}"},
+	{"(shoe)s$", "${1}"},
+	{"(cris|test)(is|es)$", "${1}is"},
+	{"^(a)x[ie]s$", "${1}xis"},
+	{"(octop|vir)(us|i)$", "${1}us"},
+	{"(alias|status)(es)?$", "${1}"},
+	{"^(ox)en", "${1}"},
+	{"(vert|ind)ices$", "${1}ex"},
+	{"(matr)ices$", "${1}ix"},
+	{"(quiz)zes$", "${1}"},
+	{"(database)s$", "${1}"},
 }
 
 var irregularInflections = IrregularSlice{
-	{singular: "person", plural: "people"},
-	{singular: "man", plural: "men"},
-	{singular: "child", plural: "children"},
-	{singular: "sex", plural: "sexes"},
-	{singular: "move", plural: "moves"},
-	{singular: "mombie", plural: "mombies"},
+	{"person", "people"},
+	{"man", "men"},
+	{"child", "children"},
+	{"sex", "sexes"},
+	{"move", "moves"},
+	{"mombie", "mombies"},
 }
 
 var uncountableInflections = []string{"equipment", "information", "rice", "money", "species", "series", "fish", "sheep", "jeans", "police"}
@@ -170,70 +176,83 @@ func init() {
 	compile()
 }
 
+// AddPlural adds a plural inflection
 func AddPlural(find, replace string) {
-	pluralInflections = append(pluralInflections, Regular{find: find, replace: replace})
+	pluralInflections = append(pluralInflections, Regular{find, replace})
 	compile()
 }
 
+// AddSingular adds a singular inflection
 func AddSingular(find, replace string) {
-	singularInflections = append(singularInflections, Regular{find: find, replace: replace})
+	singularInflections = append(singularInflections, Regular{find, replace})
 	compile()
 }
 
+// AddIrregular adds an irregular inflection
 func AddIrregular(singular, plural string) {
 	irregularInflections = append(irregularInflections, Irregular{singular, plural})
 	compile()
 }
 
-func AddUncountable(value string) {
-	uncountableInflections = append(uncountableInflections, value)
+// AddUncountable adds an uncountable inflection
+func AddUncountable(values ...string) {
+	uncountableInflections = append(uncountableInflections, values...)
 	compile()
 }
 
+// GetPlural retrieves the plural inflection values
 func GetPlural() RegularSlice {
 	plurals := make(RegularSlice, len(pluralInflections))
 	copy(plurals, pluralInflections)
 	return plurals
 }
 
+// GetSingular retrieves the singular inflection values
 func GetSingular() RegularSlice {
 	singulars := make(RegularSlice, len(singularInflections))
 	copy(singulars, singularInflections)
 	return singulars
 }
 
+// GetIrregular retrieves the irregular inflection values
 func GetIrregular() IrregularSlice {
 	irregular := make(IrregularSlice, len(irregularInflections))
 	copy(irregular, irregularInflections)
 	return irregular
 }
 
+// GetUncountable retrieves the uncountable inflection values
 func GetUncountable() []string {
 	uncountables := make([]string, len(uncountableInflections))
 	copy(uncountables, uncountableInflections)
 	return uncountables
 }
 
+// SetPlural sets the plural inflections slice
 func SetPlural(inflections RegularSlice) {
 	pluralInflections = inflections
 	compile()
 }
 
+// SetSingular sets the singular inflections slice
 func SetSingular(inflections RegularSlice) {
 	singularInflections = inflections
 	compile()
 }
 
+// SetIrregular sets the irregular inflections slice
 func SetIrregular(inflections IrregularSlice) {
 	irregularInflections = inflections
 	compile()
 }
 
+// SetUncountable sets the uncountable inflections slice
 func SetUncountable(inflections []string) {
 	uncountableInflections = inflections
 	compile()
 }
 
+// Plural converts a word to its plural form
 func Plural(str string) string {
 	for _, inflection := range compiledPluralMaps {
 		if inflection.regexp.MatchString(str) {
@@ -243,6 +262,7 @@ func Plural(str string) string {
 	return str
 }
 
+// Singular converts a word to its singular form
 func Singular(str string) string {
 	for _, inflection := range compiledSingularMaps {
 		if inflection.regexp.MatchString(str) {

--- a/inflections.go
+++ b/inflections.go
@@ -28,76 +28,89 @@ import (
 	"strings"
 )
 
-var pluralInflections = [][]string{
-	[]string{"([a-z])$", "${1}s"},
-	[]string{"s$", "s"},
-	[]string{"^(ax|test)is$", "${1}es"},
-	[]string{"(octop|vir)us$", "${1}i"},
-	[]string{"(octop|vir)i$", "${1}i"},
-	[]string{"(alias|status)$", "${1}es"},
-	[]string{"(bu)s$", "${1}ses"},
-	[]string{"(buffal|tomat)o$", "${1}oes"},
-	[]string{"([ti])um$", "${1}a"},
-	[]string{"([ti])a$", "${1}a"},
-	[]string{"sis$", "ses"},
-	[]string{"(?:([^f])fe|([lr])f)$", "${1}${2}ves"},
-	[]string{"(hive)$", "${1}s"},
-	[]string{"([^aeiouy]|qu)y$", "${1}ies"},
-	[]string{"(x|ch|ss|sh)$", "${1}es"},
-	[]string{"(matr|vert|ind)(?:ix|ex)$", "${1}ices"},
-	[]string{"^(m|l)ouse$", "${1}ice"},
-	[]string{"^(m|l)ice$", "${1}ice"},
-	[]string{"^(ox)$", "${1}en"},
-	[]string{"^(oxen)$", "${1}"},
-	[]string{"(quiz)$", "${1}zes"},
-}
-
-var singularInflections = [][]string{
-	[]string{"s$", ""},
-	[]string{"(ss)$", "${1}"},
-	[]string{"(n)ews$", "${1}ews"},
-	[]string{"([ti])a$", "${1}um"},
-	[]string{"((a)naly|(b)a|(d)iagno|(p)arenthe|(p)rogno|(s)ynop|(t)he)(sis|ses)$", "${1}sis"},
-	[]string{"(^analy)(sis|ses)$", "${1}sis"},
-	[]string{"([^f])ves$", "${1}fe"},
-	[]string{"(hive)s$", "${1}"},
-	[]string{"(tive)s$", "${1}"},
-	[]string{"([lr])ves$", "${1}f"},
-	[]string{"([^aeiouy]|qu)ies$", "${1}y"},
-	[]string{"(s)eries$", "${1}eries"},
-	[]string{"(m)ovies$", "${1}ovie"},
-	[]string{"(c)ookies$", "${1}ookie"},
-	[]string{"(x|ch|ss|sh)es$", "${1}"},
-	[]string{"^(m|l)ice$", "${1}ouse"},
-	[]string{"(bus)(es)?$", "${1}"},
-	[]string{"(o)es$", "${1}"},
-	[]string{"(shoe)s$", "${1}"},
-	[]string{"(cris|test)(is|es)$", "${1}is"},
-	[]string{"^(a)x[ie]s$", "${1}xis"},
-	[]string{"(octop|vir)(us|i)$", "${1}us"},
-	[]string{"(alias|status)(es)?$", "${1}"},
-	[]string{"^(ox)en", "${1}"},
-	[]string{"(vert|ind)ices$", "${1}ex"},
-	[]string{"(matr)ices$", "${1}ix"},
-	[]string{"(quiz)zes$", "${1}"},
-	[]string{"(database)s$", "${1}"},
-}
-
-var irregularInflections = [][]string{
-	[]string{"person", "people"},
-	[]string{"man", "men"},
-	[]string{"child", "children"},
-	[]string{"sex", "sexes"},
-	[]string{"move", "moves"},
-	[]string{"mombie", "mombies"},
-}
-
-var uncountableInflections = []string{"equipment", "information", "rice", "money", "species", "series", "fish", "sheep", "jeans", "police"}
-
 type inflection struct {
 	regexp  *regexp.Regexp
 	replace string
 }
+
+type Regular struct {
+	find    string
+	replace string
+}
+
+type Irregular struct {
+	singular string
+	plural   string
+}
+
+type RegularSlice []Regular
+type IrregularSlice []Irregular
+
+var pluralInflections = RegularSlice{
+	{find: "([a-z])$", replace: "${1}s"},
+	{find: "s$", replace: "s"},
+	{find: "^(ax|test)is$", replace: "${1}es"},
+	{find: "(octop|vir)us$", replace: "${1}i"},
+	{find: "(octop|vir)i$", replace: "${1}i"},
+	{find: "(alias|status)$", replace: "${1}es"},
+	{find: "(bu)s$", replace: "${1}ses"},
+	{find: "(buffal|tomat)o$", replace: "${1}oes"},
+	{find: "([ti])um$", replace: "${1}a"},
+	{find: "([ti])a$", replace: "${1}a"},
+	{find: "sis$", replace: "ses"},
+	{find: "(?:([^f])fe|([lr])f)$", replace: "${1}${2}ves"},
+	{find: "(hive)$", replace: "${1}s"},
+	{find: "([^aeiouy]|qu)y$", replace: "${1}ies"},
+	{find: "(x|ch|ss|sh)$", replace: "${1}es"},
+	{find: "(matr|vert|ind)(?:ix|ex)$", replace: "${1}ices"},
+	{find: "^(m|l)ouse$", replace: "${1}ice"},
+	{find: "^(m|l)ice$", replace: "${1}ice"},
+	{find: "^(ox)$", replace: "${1}en"},
+	{find: "^(oxen)$", replace: "${1}"},
+	{find: "(quiz)$", replace: "${1}zes"},
+}
+
+var singularInflections = RegularSlice{
+	{find: "s$", replace: ""},
+	{find: "(ss)$", replace: "${1}"},
+	{find: "(n)ews$", replace: "${1}ews"},
+	{find: "([ti])a$", replace: "${1}um"},
+	{find: "((a)naly|(b)a|(d)iagno|(p)arenthe|(p)rogno|(s)ynop|(t)he)(sis|ses)$", replace: "${1}sis"},
+	{find: "(^analy)(sis|ses)$", replace: "${1}sis"},
+	{find: "([^f])ves$", replace: "${1}fe"},
+	{find: "(hive)s$", replace: "${1}"},
+	{find: "(tive)s$", replace: "${1}"},
+	{find: "([lr])ves$", replace: "${1}f"},
+	{find: "([^aeiouy]|qu)ies$", replace: "${1}y"},
+	{find: "(s)eries$", replace: "${1}eries"},
+	{find: "(m)ovies$", replace: "${1}ovie"},
+	{find: "(c)ookies$", replace: "${1}ookie"},
+	{find: "(x|ch|ss|sh)es$", replace: "${1}"},
+	{find: "^(m|l)ice$", replace: "${1}ouse"},
+	{find: "(bus)(es)?$", replace: "${1}"},
+	{find: "(o)es$", replace: "${1}"},
+	{find: "(shoe)s$", replace: "${1}"},
+	{find: "(cris|test)(is|es)$", replace: "${1}is"},
+	{find: "^(a)x[ie]s$", replace: "${1}xis"},
+	{find: "(octop|vir)(us|i)$", replace: "${1}us"},
+	{find: "(alias|status)(es)?$", replace: "${1}"},
+	{find: "^(ox)en", replace: "${1}"},
+	{find: "(vert|ind)ices$", replace: "${1}ex"},
+	{find: "(matr)ices$", replace: "${1}ix"},
+	{find: "(quiz)zes$", replace: "${1}"},
+	{find: "(database)s$", replace: "${1}"},
+}
+
+var irregularInflections = IrregularSlice{
+	{singular: "person", plural: "people"},
+	{singular: "man", plural: "men"},
+	{singular: "child", plural: "children"},
+	{singular: "sex", plural: "sexes"},
+	{singular: "move", plural: "moves"},
+	{singular: "mombie", plural: "mombies"},
+}
+
+var uncountableInflections = []string{"equipment", "information", "rice", "money", "species", "series", "fish", "sheep", "jeans", "police"}
 
 var compiledPluralMaps []inflection
 var compiledSingularMaps []inflection
@@ -116,18 +129,18 @@ func compile() {
 
 	for _, value := range irregularInflections {
 		infs := []inflection{
-			inflection{regexp: regexp.MustCompile(strings.ToUpper(value[0]) + "$"), replace: strings.ToUpper(value[1])},
-			inflection{regexp: regexp.MustCompile(strings.Title(value[0]) + "$"), replace: strings.Title(value[1])},
-			inflection{regexp: regexp.MustCompile(value[0] + "$"), replace: value[1]},
+			inflection{regexp: regexp.MustCompile(strings.ToUpper(value.singular) + "$"), replace: strings.ToUpper(value.plural)},
+			inflection{regexp: regexp.MustCompile(strings.Title(value.singular) + "$"), replace: strings.Title(value.plural)},
+			inflection{regexp: regexp.MustCompile(value.singular + "$"), replace: value.plural},
 		}
 		compiledPluralMaps = append(compiledPluralMaps, infs...)
 	}
 
 	for _, value := range irregularInflections {
 		infs := []inflection{
-			inflection{regexp: regexp.MustCompile(strings.ToUpper(value[1]) + "$"), replace: strings.ToUpper(value[0])},
-			inflection{regexp: regexp.MustCompile(strings.Title(value[1]) + "$"), replace: strings.Title(value[0])},
-			inflection{regexp: regexp.MustCompile(value[1] + "$"), replace: value[0]},
+			inflection{regexp: regexp.MustCompile(strings.ToUpper(value.plural) + "$"), replace: strings.ToUpper(value.singular)},
+			inflection{regexp: regexp.MustCompile(strings.Title(value.plural) + "$"), replace: strings.Title(value.singular)},
+			inflection{regexp: regexp.MustCompile(value.plural + "$"), replace: value.singular},
 		}
 		compiledSingularMaps = append(compiledSingularMaps, infs...)
 	}
@@ -135,9 +148,9 @@ func compile() {
 	for i := len(pluralInflections) - 1; i >= 0; i-- {
 		value := pluralInflections[i]
 		infs := []inflection{
-			inflection{regexp: regexp.MustCompile(strings.ToUpper(value[0])), replace: strings.ToUpper(value[1])},
-			inflection{regexp: regexp.MustCompile(value[0]), replace: value[1]},
-			inflection{regexp: regexp.MustCompile("(?i)" + value[0]), replace: value[1]},
+			inflection{regexp: regexp.MustCompile(strings.ToUpper(value.find)), replace: strings.ToUpper(value.replace)},
+			inflection{regexp: regexp.MustCompile(value.find), replace: value.replace},
+			inflection{regexp: regexp.MustCompile("(?i)" + value.find), replace: value.replace},
 		}
 		compiledPluralMaps = append(compiledPluralMaps, infs...)
 	}
@@ -145,9 +158,9 @@ func compile() {
 	for i := len(singularInflections) - 1; i >= 0; i-- {
 		value := singularInflections[i]
 		infs := []inflection{
-			inflection{regexp: regexp.MustCompile(strings.ToUpper(value[0])), replace: strings.ToUpper(value[1])},
-			inflection{regexp: regexp.MustCompile(value[0]), replace: value[1]},
-			inflection{regexp: regexp.MustCompile("(?i)" + value[0]), replace: value[1]},
+			inflection{regexp: regexp.MustCompile(strings.ToUpper(value.find)), replace: strings.ToUpper(value.replace)},
+			inflection{regexp: regexp.MustCompile(value.find), replace: value.replace},
+			inflection{regexp: regexp.MustCompile("(?i)" + value.find), replace: value.replace},
 		}
 		compiledSingularMaps = append(compiledSingularMaps, infs...)
 	}
@@ -157,23 +170,67 @@ func init() {
 	compile()
 }
 
-func AddPlural(key, value string) {
-	pluralInflections = append(pluralInflections, []string{key, value})
+func AddPlural(find, replace string) {
+	pluralInflections = append(pluralInflections, Regular{find: find, replace: replace})
 	compile()
 }
 
-func AddSingular(key, value string) {
-	singularInflections = append(singularInflections, []string{key, value})
+func AddSingular(find, replace string) {
+	singularInflections = append(singularInflections, Regular{find: find, replace: replace})
 	compile()
 }
 
-func AddIrregular(key, value string) {
-	irregularInflections = append(irregularInflections, []string{key, value})
+func AddIrregular(singular, plural string) {
+	irregularInflections = append(irregularInflections, Irregular{singular, plural})
 	compile()
 }
 
 func AddUncountable(value string) {
 	uncountableInflections = append(uncountableInflections, value)
+	compile()
+}
+
+func GetPlural() RegularSlice {
+	plurals := make(RegularSlice, len(pluralInflections))
+	copy(plurals, pluralInflections)
+	return plurals
+}
+
+func GetSingular() RegularSlice {
+	singulars := make(RegularSlice, len(singularInflections))
+	copy(singulars, singularInflections)
+	return singulars
+}
+
+func GetIrregular() IrregularSlice {
+	irregular := make(IrregularSlice, len(irregularInflections))
+	copy(irregular, irregularInflections)
+	return irregular
+}
+
+func GetUncountable() []string {
+	uncountables := make([]string, len(uncountableInflections))
+	copy(uncountables, uncountableInflections)
+	return uncountables
+}
+
+func SetPlural(inflections RegularSlice) {
+	pluralInflections = inflections
+	compile()
+}
+
+func SetSingular(inflections RegularSlice) {
+	singularInflections = inflections
+	compile()
+}
+
+func SetIrregular(inflections IrregularSlice) {
+	irregularInflections = inflections
+	compile()
+}
+
+func SetUncountable(inflections []string) {
+	uncountableInflections = inflections
 	compile()
 }
 

--- a/inflections_test.go
+++ b/inflections_test.go
@@ -8,7 +8,6 @@ import (
 var inflections = map[string]string{
 	"star":        "stars",
 	"STAR":        "STARS",
-	"STaR":        "STaRS",
 	"Star":        "Stars",
 	"bus":         "buses",
 	"fish":        "fish",
@@ -92,6 +91,38 @@ func TestSingular(t *testing.T) {
 		if v := Singular(value); v != key {
 			t.Errorf("%v's singular should be %v, but got %v", value, key, v)
 		}
+	}
+}
+
+func TestAddPlural(t *testing.T) {
+	ln := len(pluralInflections)
+	AddPlural("", "")
+	if ln+1 != len(pluralInflections) {
+		t.Errorf("Expected len %d, got %d", ln+1, len(pluralInflections))
+	}
+}
+
+func TestAddSingular(t *testing.T) {
+	ln := len(singularInflections)
+	AddSingular("", "")
+	if ln+1 != len(singularInflections) {
+		t.Errorf("Expected len %d, got %d", ln+1, len(singularInflections))
+	}
+}
+
+func TestAddIrregular(t *testing.T) {
+	ln := len(irregularInflections)
+	AddIrregular("", "")
+	if ln+1 != len(irregularInflections) {
+		t.Errorf("Expected len %d, got %d", ln+1, len(irregularInflections))
+	}
+}
+
+func TestAddUncountable(t *testing.T) {
+	ln := len(uncountableInflections)
+	AddUncountable("", "")
+	if ln+2 != len(uncountableInflections) {
+		t.Errorf("Expected len %d, got %d", ln+2, len(uncountableInflections))
 	}
 }
 

--- a/inflections_test.go
+++ b/inflections_test.go
@@ -1,15 +1,14 @@
-package inflection_test
+package inflection
 
 import (
 	"strings"
 	"testing"
-
-	"github.com/qor/inflection"
 )
 
 var inflections = map[string]string{
 	"star":        "stars",
 	"STAR":        "STARS",
+	"STaR":        "STaRS",
 	"Star":        "Stars",
 	"bus":         "buses",
 	"fish":        "fish",
@@ -61,20 +60,20 @@ var inflections = map[string]string{
 }
 
 func init() {
-	inflection.AddIrregular("criterion", "criteria")
+	AddIrregular("criterion", "criteria")
 }
 
 func TestPlural(t *testing.T) {
 	for key, value := range inflections {
-		if v := inflection.Plural(strings.ToUpper(key)); v != strings.ToUpper(value) {
+		if v := Plural(strings.ToUpper(key)); v != strings.ToUpper(value) {
 			t.Errorf("%v's plural should be %v, but got %v", strings.ToUpper(key), strings.ToUpper(value), v)
 		}
 
-		if v := inflection.Plural(strings.Title(key)); v != strings.Title(value) {
+		if v := Plural(strings.Title(key)); v != strings.Title(value) {
 			t.Errorf("%v's plural should be %v, but got %v", strings.Title(key), strings.Title(value), v)
 		}
 
-		if v := inflection.Plural(key); v != value {
+		if v := Plural(key); v != value {
 			t.Errorf("%v's plural should be %v, but got %v", key, value, v)
 		}
 	}
@@ -82,16 +81,72 @@ func TestPlural(t *testing.T) {
 
 func TestSingular(t *testing.T) {
 	for key, value := range inflections {
-		if v := inflection.Singular(strings.ToUpper(value)); v != strings.ToUpper(key) {
+		if v := Singular(strings.ToUpper(value)); v != strings.ToUpper(key) {
 			t.Errorf("%v's singular should be %v, but got %v", strings.ToUpper(value), strings.ToUpper(key), v)
 		}
 
-		if v := inflection.Singular(strings.Title(value)); v != strings.Title(key) {
+		if v := Singular(strings.Title(value)); v != strings.Title(key) {
 			t.Errorf("%v's singular should be %v, but got %v", strings.Title(value), strings.Title(key), v)
 		}
 
-		if v := inflection.Singular(value); v != key {
+		if v := Singular(value); v != key {
 			t.Errorf("%v's singular should be %v, but got %v", value, key, v)
 		}
+	}
+}
+
+func TestGetPlural(t *testing.T) {
+	plurals := GetPlural()
+	if len(plurals) != len(pluralInflections) {
+		t.Errorf("Expected len %d, got %d", len(plurals), len(pluralInflections))
+	}
+}
+
+func TestGetSingular(t *testing.T) {
+	singular := GetSingular()
+	if len(singular) != len(singularInflections) {
+		t.Errorf("Expected len %d, got %d", len(singular), len(singularInflections))
+	}
+}
+
+func TestGetIrregular(t *testing.T) {
+	irregular := GetIrregular()
+	if len(irregular) != len(irregularInflections) {
+		t.Errorf("Expected len %d, got %d", len(irregular), len(irregularInflections))
+	}
+}
+
+func TestGetUncountable(t *testing.T) {
+	uncountables := GetUncountable()
+	if len(uncountables) != len(uncountableInflections) {
+		t.Errorf("Expected len %d, got %d", len(uncountables), len(uncountableInflections))
+	}
+}
+
+func TestSetPlural(t *testing.T) {
+	SetPlural(RegularSlice{{}, {}})
+	if len(pluralInflections) != 2 {
+		t.Errorf("Expected len 2, got %d", len(pluralInflections))
+	}
+}
+
+func TestSetSingular(t *testing.T) {
+	SetSingular(RegularSlice{{}, {}})
+	if len(singularInflections) != 2 {
+		t.Errorf("Expected len 2, got %d", len(singularInflections))
+	}
+}
+
+func TestSetIrregular(t *testing.T) {
+	SetIrregular(IrregularSlice{{}, {}})
+	if len(irregularInflections) != 2 {
+		t.Errorf("Expected len 2, got %d", len(irregularInflections))
+	}
+}
+
+func TestSetUncountable(t *testing.T) {
+	SetUncountable([]string{"", ""})
+	if len(uncountableInflections) != 2 {
+		t.Errorf("Expected len 2, got %d", len(uncountableInflections))
 	}
 }

--- a/inflections_test.go
+++ b/inflections_test.go
@@ -58,8 +58,30 @@ var inflections = map[string]string{
 	"criterion":   "criteria",
 }
 
+// storage is used to restore the state of the global variables
+// on each test execution, to ensure no global state pollution
+type storage struct {
+	singulars    RegularSlice
+	plurals      RegularSlice
+	irregulars   IrregularSlice
+	uncountables []string
+}
+
+var backup = storage{}
+
 func init() {
 	AddIrregular("criterion", "criteria")
+	copy(backup.singulars, singularInflections)
+	copy(backup.plurals, pluralInflections)
+	copy(backup.irregulars, irregularInflections)
+	copy(backup.uncountables, uncountableInflections)
+}
+
+func restore() {
+	copy(singularInflections, backup.singulars)
+	copy(pluralInflections, backup.plurals)
+	copy(irregularInflections, backup.irregulars)
+	copy(uncountableInflections, backup.uncountables)
 }
 
 func TestPlural(t *testing.T) {
@@ -95,6 +117,7 @@ func TestSingular(t *testing.T) {
 }
 
 func TestAddPlural(t *testing.T) {
+	defer restore()
 	ln := len(pluralInflections)
 	AddPlural("", "")
 	if ln+1 != len(pluralInflections) {
@@ -103,6 +126,7 @@ func TestAddPlural(t *testing.T) {
 }
 
 func TestAddSingular(t *testing.T) {
+	defer restore()
 	ln := len(singularInflections)
 	AddSingular("", "")
 	if ln+1 != len(singularInflections) {
@@ -111,6 +135,7 @@ func TestAddSingular(t *testing.T) {
 }
 
 func TestAddIrregular(t *testing.T) {
+	defer restore()
 	ln := len(irregularInflections)
 	AddIrregular("", "")
 	if ln+1 != len(irregularInflections) {
@@ -119,6 +144,7 @@ func TestAddIrregular(t *testing.T) {
 }
 
 func TestAddUncountable(t *testing.T) {
+	defer restore()
 	ln := len(uncountableInflections)
 	AddUncountable("", "")
 	if ln+2 != len(uncountableInflections) {
@@ -155,6 +181,7 @@ func TestGetUncountable(t *testing.T) {
 }
 
 func TestSetPlural(t *testing.T) {
+	defer restore()
 	SetPlural(RegularSlice{{}, {}})
 	if len(pluralInflections) != 2 {
 		t.Errorf("Expected len 2, got %d", len(pluralInflections))
@@ -162,6 +189,7 @@ func TestSetPlural(t *testing.T) {
 }
 
 func TestSetSingular(t *testing.T) {
+	defer restore()
 	SetSingular(RegularSlice{{}, {}})
 	if len(singularInflections) != 2 {
 		t.Errorf("Expected len 2, got %d", len(singularInflections))
@@ -169,6 +197,7 @@ func TestSetSingular(t *testing.T) {
 }
 
 func TestSetIrregular(t *testing.T) {
+	defer restore()
 	SetIrregular(IrregularSlice{{}, {}})
 	if len(irregularInflections) != 2 {
 		t.Errorf("Expected len 2, got %d", len(irregularInflections))
@@ -176,6 +205,7 @@ func TestSetIrregular(t *testing.T) {
 }
 
 func TestSetUncountable(t *testing.T) {
+	defer restore()
 	SetUncountable([]string{"", ""})
 	if len(uncountableInflections) != 2 {
 		t.Errorf("Expected len 2, got %d", len(uncountableInflections))


### PR DESCRIPTION
All changes are backwards compatible with the previous version of this library.

- Replaced [][]string slices with []structs:
  This should be more efficient as a string slice allocates a struct with 3 parts (int, int, *array), and then you have to pay for 2 more slices for each string.
  In the struct version, you only get 2 parts (string, string). It's a more direct way to store things, less indirection. It also allows us to be more clear with the struct names what each part is since it has a field name.
- Added Set/Get methods for the rule sets to allow further customization and more efficient manipulation of multiple values (less compile() calls, can remove items)
- Added variadic arguments (backwards compatible) to the AddUncountable method to allow for more efficient setting of multiple values (less compile() calls)
- Added tests for all methods
- Added test setup/teardown for global state in tests
- Removed testing reference to old library, and use same-package tests
- Added comments for all exported values (as per golint)