### PR TITLE
fix plural for drive(s)

### DIFF
--- a/inflections.go
+++ b/inflections.go
@@ -74,6 +74,7 @@ var pluralInflections = RegularSlice{
 	{"^(ox)$", "${1}en"},
 	{"^(oxen)$", "${1}"},
 	{"(quiz)$", "${1}zes"},
+	{"(drive)$", "${1}s"},
 }
 
 var singularInflections = RegularSlice{
@@ -105,6 +106,7 @@ var singularInflections = RegularSlice{
 	{"(matr)ices$", "${1}ix"},
 	{"(quiz)zes$", "${1}"},
 	{"(database)s$", "${1}"},
+	{"(drive)s$", "${1}"},
 }
 
 var irregularInflections = IrregularSlice{

--- a/inflections_test.go
+++ b/inflections_test.go
@@ -77,6 +77,8 @@ var inflections = map[string]string{
 	"traffic":     "traffic",
 	"zombie":      "zombies",
 	"campus":      "campuses",
+	"harddrive":   "harddrives",
+	"drive":       "drives",
 }
 
 // storage is used to restore the state of the global variables


### PR DESCRIPTION
found a small bug when it comes to `drive(s)` like `harddrive(s)`. it currently singularizes to `drife` and `harddrife`