### PR TITLE
Add leaf as an irregular inflection

### DIFF
--- a/inflections.go
+++ b/inflections.go
@@ -120,6 +120,7 @@ var irregularInflections = IrregularSlice{
 	{"foot", "feet"},
 	{"moose", "moose"},
 	{"tooth", "teeth"},
+	{"leaf", "leaves"},
 }
 
 var uncountableInflections = []string{"equipment", "information", "rice", "money", "species", "series", "fish", "sheep", "jeans", "police", "milk", "salt", "time", "water", "paper", "food", "art", "cash", "music", "help", "luck", "oil", "progress", "rain", "research", "shopping", "software", "traffic"}

--- a/inflections_test.go
+++ b/inflections_test.go
@@ -79,6 +79,7 @@ var inflections = map[string]string{
 	"campus":      "campuses",
 	"harddrive":   "harddrives",
 	"drive":       "drives",
+	"leaf":        "leaves",
 }
 
 // storage is used to restore the state of the global variables


### PR DESCRIPTION
I was running into a problem with gorm in which a model named leaf was producing incorrect pluralization. After a little digging, it seems that the issue is from a minor bug in the inflection library.

While some regex in the regular inflections slice that is close, none match the word "leaf", so, in order to stay with using a regex set that is the same as rails, seems like the irregular inflection set is the appropriate place.

Also, seems somebody else had a similar [issue 24](https://github.com/jinzhu/inflection/issues/24)