### PR TITLE
The plural of chassis is chassis

### DIFF
--- a/inflections.go
+++ b/inflections.go
@@ -120,6 +120,7 @@ var irregularInflections = IrregularSlice{
 	{"foot", "feet"},
 	{"moose", "moose"},
 	{"tooth", "teeth"},
+	{"chassis", "chassis"}
 }
 
 var uncountableInflections = []string{"equipment", "information", "rice", "money", "species", "series", "fish", "sheep", "jeans", "police", "milk", "salt", "time", "water", "paper", "food", "art", "cash", "music", "help", "luck", "oil", "progress", "rain", "research", "shopping", "software", "traffic"}


### PR DESCRIPTION
https://preply.com/en/question/plural-of-chassis

We are facing issues in go-mysqlmock tests because the table is being fetched and "chasses"